### PR TITLE
fix: Log out of discord when the app exits

### DIFF
--- a/app.js
+++ b/app.js
@@ -128,5 +128,6 @@ wsServer.on('connection', (socket, req) => {
 process.on('SIGINT', () => {
   CLOG('Shutting down!')
   wsServer.clients.forEach(s => s.send('Server is shutting down! This is most likely a deliberate act by the admin.'))
+  discord.logout()
   process.exit()
 })


### PR DESCRIPTION
zaps: https://github.com/dreeves/lexiguess/issues/33

We should log out when the app shuts down.